### PR TITLE
Replace mousetrap with combokeys

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ Create a new JS, Coffee, JSON or CSON file wherever you want (which probably is 
   shortcut may be composed of single keys (`a`, `6`,…), combinations
   (`command+shift+k`) or sequences (`up up down down left right left right B A`).
 
-> **Mousetrap** is used under the
-  hood for handling the shortcuts. [Read more][mousetrap] about how you can
+> **Combokeys** is used under the
+  hood for handling the shortcuts. [Read more][combokeys] about how you can
   specify keys.
 
 
@@ -190,5 +190,5 @@ This library is inspired by [Atom Keymap].
 
 [Atom Keymap]: https://github.com/atom/atom-keymap/
 [travis]: https://travis-ci.org/avocode/react-shortcuts
-[mousetrap]: https://craig.is/killing/mice
+[combokeys]: https://github.com/PolicyStat/combokeys
 [keymaps]: https://github.com/atom/atom-keymap/

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "react-component",
     "keyboard",
     "shortcuts",
-    "mousetrap"
+    "mousetrap",
+    "combokeys"
   ],
   "scripts": {
     "prepublish": "coffee -o ./ src/",
@@ -25,9 +26,9 @@
   },
   "dependencies": {
     "classnames": "^2.1.3",
+    "combokeys": "^2.4.6",
     "events": "^1.0.2",
     "invariant": "^2.1.0",
-    "mousetrap": "^1.5.3",
     "platform": "^1.3.0"
   },
   "peerDependencies": {

--- a/src/component/shortcuts.coffee
+++ b/src/component/shortcuts.coffee
@@ -122,5 +122,6 @@ module.exports = React.createClass
       tabIndex: @props.tabIndex or -1
       ref: @props.ref
       className: @props.className,
+      style: @props.style
 
       @props.children

--- a/src/component/shortcuts.coffee
+++ b/src/component/shortcuts.coffee
@@ -119,6 +119,7 @@ module.exports = React.createClass
     element = shortcuts
 
     element
+      id: @props.id
       tabIndex: @props.tabIndex or -1
       ref: @props.ref
       className: @props.className,

--- a/src/component/shortcuts.coffee
+++ b/src/component/shortcuts.coffee
@@ -1,7 +1,7 @@
 React = require 'react'
 ReactDOM = require 'react-dom'
 invariant = require 'invariant'
-createMousetrap = require 'mousetrap'
+Combokeys = require 'combokeys'
 
 shortcuts = React.createFactory 'shortcuts'
 
@@ -9,8 +9,8 @@ shortcuts = React.createFactory 'shortcuts'
 module.exports = React.createClass
   displayName: 'Shortcuts'
 
-  # NOTE: mousetrap must be instance per component
-  _mousetrap: null
+  # NOTE: combokeys must be instance per component
+  _combokeys: null
 
   contextTypes:
     shortcuts: React.PropTypes.object.isRequired
@@ -40,9 +40,9 @@ module.exports = React.createClass
   _bindShortcuts: (shortcutsArr) ->
     element = @_getElementToBind()
     element.setAttribute('tabindex', @props.tabIndex or -1)
-    @_mousetrap = createMousetrap(element)
-    @_monkeyPatchMousetrap()
-    @_mousetrap.bind(shortcutsArr, @_handleShortcuts, @props.eventType)
+    @_combokeys = new Combokeys(element)
+    @_monkeyPatchCombokeys()
+    @_combokeys.bind(shortcutsArr, @_handleShortcuts, @props.eventType)
 
     if @props.isGlobal
       element.addEventListener 'shortcuts:global', @_customGlobalHandler
@@ -53,15 +53,15 @@ module.exports = React.createClass
     if e.target isnt ReactDOM.findDOMNode(this) and
         e.target isnt @props.targetNode
       # NOTE: this is kind of hack
-      @_mousetrap._handleKey(character, modifiers, event, true)
+      @_combokeys._handleKey(character, modifiers, event, true)
 
   _lastEvent: null
 
-  _monkeyPatchMousetrap: ->
+  _monkeyPatchCombokeys: ->
     element = @_getElementToBind()
-    originalHandleKey = @_mousetrap._handleKey
+    originalHandleKey = @_combokeys._handleKey
 
-    @_mousetrap._handleKey = (character, modifiers, event, customEvent) =>
+    @_combokeys._handleKey = (character, modifiers, event, customEvent) =>
       if not customEvent
         element.dispatchEvent new CustomEvent 'shortcuts:global',
           detail: {character, modifiers, event}
@@ -88,9 +88,9 @@ module.exports = React.createClass
     element = @_getElementToBind()
     element.removeAttribute('tabindex')
 
-    if @_mousetrap
-      @_mousetrap.unbind(shortcutsArr, @props.eventType)
-      @_mousetrap.reset()
+    if @_combokeys
+      @_combokeys.unbind(shortcutsArr, @props.eventType)
+      @_combokeys.reset()
 
   _onUpdate: ->
     shortcutsArr = @context.shortcuts.getShortcuts(@props.name)

--- a/test/shortcuts.spec.coffee
+++ b/test/shortcuts.spec.coffee
@@ -74,6 +74,7 @@ describe 'Shortcuts component: ', ->
 
     before ->
       props.className = 'testing-class'
+      props.style = color: 'blue'
       element = ReactTestUtils.renderIntoDocument React.createElement(Test)
 
     it 'should create a <shortcuts> DOM element', ->
@@ -87,6 +88,10 @@ describe 'Shortcuts component: ', ->
     it 'should add a className to the <shortcuts> element', ->
       el = ReactDOM.findDOMNode(element).querySelector('shortcuts')
       expect(el.className).toBe('testing-class')
+
+    it 'should add a style to the <shortcuts> element', ->
+      el = ReactDOM.findDOMNode(element).querySelector('shortcuts')
+      expect(el.style.color).toBe('blue')
 
     it 'should use a custom tabindex attribute value', ->
       props.tabIndex = 666

--- a/test/shortcuts.spec.coffee
+++ b/test/shortcuts.spec.coffee
@@ -73,6 +73,7 @@ describe 'Shortcuts component: ', ->
     element = null
 
     before ->
+      props.id = 'my-id'
       props.className = 'testing-class'
       props.style = color: 'blue'
       element = ReactTestUtils.renderIntoDocument React.createElement(Test)
@@ -84,6 +85,10 @@ describe 'Shortcuts component: ', ->
       el = ReactDOM.findDOMNode(element).querySelector('shortcuts')
       expect(el.getAttribute('tabindex')).toExist()
       expect(el.getAttribute('tabindex')).toBe('-1')
+
+    it 'should add an id to the <shortcuts> element', ->
+      el = ReactDOM.findDOMNode(element).querySelector('shortcuts')
+      expect(el.id).toBe('my-id')
 
     it 'should add a className to the <shortcuts> element', ->
       el = ReactDOM.findDOMNode(element).querySelector('shortcuts')


### PR DESCRIPTION
I replaced mousetrap with combokeys, since combokeys is able to be loaded in a webworker without throwing an exception. All existing tests are passing, and combokeys has been working well so far in my testing.

I also added support for passing "id" and "style" props to the shortcuts component, and added tests for this functionality.