### PR TITLE
Handle null `platform.os.family`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ Create a new JS, Coffee, JSON or CSON file wherever you want (which probably is 
    "Action_3": {
      "osx": "Shortcut",
      "windows": ["Shortcut", "Shortcut"],
-     "linux": "Shortcut"
+     "linux": "Shortcut",
+     "other": "Shortcut",
    }
  }
 }
@@ -65,7 +66,7 @@ Create a new JS, Coffee, JSON or CSON file wherever you want (which probably is 
 - `Namespace` should ideally be the component’s `displayName`.
 - `Action` describes what will be happening. For example `MODAL_CLOSE`.
 - `Keyboard shortcut` can be a string, array of strings or an object which
-  specifies platform differences (Windows, OSX, Linux). The
+  specifies platform differences (Windows, OSX, Linux, other). The
   shortcut may be composed of single keys (`a`, `6`,…), combinations
   (`command+shift+k`) or sequences (`up up down down left right left right B A`).
 
@@ -87,6 +88,7 @@ module.exports =
       osx: 'command+c'
       windows: 'ctrl+c'
       linux: 'ctrl+c'
+      other: 'ctrl+c'
 ```
 
 Save this file as `keymap.[js|coffee|json|cson]` and require it into your main

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Create a new JS, Coffee, JSON or CSON file wherever you want (which probably is 
      "osx": "Shortcut",
      "windows": ["Shortcut", "Shortcut"],
      "linux": "Shortcut",
-     "other": "Shortcut",
+     "other": "Shortcut"
    }
  }
 }

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,7 +1,7 @@
 import platform from 'platform'
 
 let getPlatformName = function() {
-  let os = platform.os.family
+  let os = platform.os.family || ''
   os = os.toLowerCase().replace(/ /g, '')
   if (/\bwin/.test(os)) {
     os = 'windows'

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -9,6 +9,8 @@ let getPlatformName = function() {
     os = 'osx'
   } else if (/freebsd|sunos/.test(os)) {
     os = 'linux'
+  } else {
+    os = 'other'
   }
   return os
 }

--- a/test/keymap.js
+++ b/test/keymap.js
@@ -6,7 +6,8 @@ export default {
     DELETE: {
       osx: 'alt+backspace',
       windows: 'delete',
-      linux: 'alt+backspace'
+      linux: 'alt+backspace',
+      other: 'alt+backspace'
     }
   },
   Next: {
@@ -15,7 +16,8 @@ export default {
     CLOSE: {
       osx: ['esc', 'enter'],
       windows: ['esc', 'enter'],
-      linux: ['esc', 'enter']
+      linux: ['esc', 'enter'],
+      other: ['esc', 'enter']
     }
   },
   'TESTING': {


### PR DESCRIPTION
This occurs for certain OSes, like Chrome OS.

Per platform documentation[0], `platform.os.family` can be a string OR `null`.

[0] https://github.com/bestiejs/platform.js/blob/master/doc/README.md#platformosfamily