### PR TITLE
prevent failure when no other platform specified

### DIFF
--- a/src/shortcut-manager.js
+++ b/src/shortcut-manager.js
@@ -51,7 +51,7 @@ class ShortcutManager extends EventEmitter {
       `getShortcuts: There are no shortcuts with name ${componentName}.`)
 
     let _parseShortcutDescriptor = this._parseShortcutDescriptor.bind(this)
-    let shortcuts = _(cursor).map(_parseShortcutDescriptor).flatten().value()
+    let shortcuts = _(cursor).map(_parseShortcutDescriptor).flatten().compact().value()
 
     return shortcuts
   }


### PR DESCRIPTION
`undefined` values appear in the `shortcuts` array when no `other` keymap is specified. Added `.compact()` to remove them.