### PR TITLE
replace invariant with warnings when getting undefined key from keymap

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -4,5 +4,4 @@
 <div id="app"></div>
 
 <script src="/node_modules/react/dist/react-with-addons.js"></script>
-<script src="/node_modules/lodash/index.js"></script>
 <script src="/index.js"></script>

--- a/src/shortcut-manager.js
+++ b/src/shortcut-manager.js
@@ -3,6 +3,13 @@ import invariant from 'invariant'
 import { EventEmitter } from 'events'
 import helpers from './helpers'
 
+
+const warning = (text) => {
+  if (process.env.NODE_ENV !== 'production') {
+    console.warn(text)
+  }
+}
+
 class ShortcutManager extends EventEmitter {
   static CHANGE_EVENT = 'shortcuts:update'
 
@@ -47,8 +54,10 @@ class ShortcutManager extends EventEmitter {
       'getShortcuts: name argument is not defined or falsy.')
 
     let cursor = this._keymap[componentName]
-    invariant(cursor,
-      `getShortcuts: There are no shortcuts with name ${componentName}.`)
+    if (!cursor) {
+      warning(`getShortcuts: There are no shortcuts with name ${componentName}.`)
+      return
+    }
 
     let _parseShortcutDescriptor = this._parseShortcutDescriptor.bind(this)
     let shortcuts = _(cursor).map(_parseShortcutDescriptor).flatten().compact().value()

--- a/test/shortcut-manager.spec.js
+++ b/test/shortcut-manager.spec.js
@@ -78,10 +78,10 @@ describe('Shortcut manager', function() {
     expect(shortcuts.length).to.be.equal(5)
   })
 
-  it('should throw an error', function() {
+  it('should not throw an error when getting not existing key from keymap', function() {
     let manager = new ShortcutManager(keymap)
     let notExist = () => manager.getShortcuts('NotExist')
-    expect(notExist).to.throw(/getShortcuts: There are no shortcuts with name NotExist./)
+    expect(notExist).to.not.throw()
   })
 
   it('findShortcutName: should return correct key label', function() {


### PR DESCRIPTION
I checked how do Facebook developers handle `NODE_ENV` in the browser.

They basically don't care until they do the `umd` build for the browser.

So if they just transpile to `ES5` they do not mock `process.env.NODE_ENV` anyhow.

So I did the same thing and I'll expect that build programs will do their job.