### PR TITLE
avoid shortcut trigger when typing text in safari

### DIFF
--- a/src/component/shortcuts.js
+++ b/src/component/shortcuts.js
@@ -77,8 +77,13 @@ export default class extends React.Component {
       let isInputLikeElement = element.tagName === 'INPUT' ||
         element.tagName === 'SELECT' || element.tagName === 'TEXTAREA' ||
           (element.contentEditable && element.contentEditable === 'true')
-      let isReturnString = event.key && event.key.length === 1
-
+        var isReturnString;
+        if (event.key !== undefined) {
+          isReturnString = event.key && event.key.length === 1;
+        } else { // safari doesn't support KeyboardEvent.key
+          isReturnString = (typeof event.which == "number") ? event.which : event.keyCode
+        }
+      
       if (isInputLikeElement && isReturnString) {
         return true
       }

--- a/src/component/shortcuts.js
+++ b/src/component/shortcuts.js
@@ -77,11 +77,11 @@ export default class extends React.Component {
       let isInputLikeElement = element.tagName === 'INPUT' ||
         element.tagName === 'SELECT' || element.tagName === 'TEXTAREA' ||
           (element.contentEditable && element.contentEditable === 'true')
-        var isReturnString;
+        let isReturnString
         if (event.key !== undefined) {
-          isReturnString = event.key && event.key.length === 1;
+          isReturnString = event.key && event.key.length === 1
         } else { // safari doesn't support KeyboardEvent.key
-          isReturnString = (typeof event.which == "number") ? event.which : event.keyCode
+          isReturnString = !!((typeof event.which == "number") ? event.which : event.keyCode)
         }
       
       if (isInputLikeElement && isReturnString) {


### PR DESCRIPTION
Safari doesn't yet implement KeyboardEvent.key ( https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key ).
The hack comes from Stack Overflow: http://stackoverflow.com/a/4285801/72637