### PR TITLE
chore: use createElement instead of createFactory

### DIFF
--- a/src/component/shortcuts.js
+++ b/src/component/shortcuts.js
@@ -4,9 +4,6 @@ import Combokeys from 'combokeys'
 
 import helpers from '../helpers'
 
-const shortcuts = React.createFactory('shortcuts')
-
-
 export default class extends React.Component {
   static displayName = 'Shortcuts'
 
@@ -183,7 +180,7 @@ export default class extends React.Component {
 
   render() {
     return (
-      shortcuts({
+      React.createElement('shortcuts', {
         ref: (node) => { this._domNode = node },
         tabIndex: this.props.tabIndex || -1,
         className: this.props.className,


### PR DESCRIPTION
`React.createFactory()` is deprecated, `React.createElement()` should be used directly.

**Untested**