### PR TITLE
Migrate from React.PropTypes

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ class App extends React.Component {
 }
 
 App.childContextTypes = {
-  shortcuts: React.PropTypes.object.isRequired
+  shortcuts: PropTypes.object.isRequired
 }
 ```
 

--- a/example/app.js
+++ b/example/app.js
@@ -1,3 +1,5 @@
+import PropTypes from 'prop-types'
+
 let { Shortcuts } = require('../src')
 
 Shortcuts = React.createFactory(Shortcuts)
@@ -7,7 +9,7 @@ export default React.createClass({
   displayName: 'App',
 
   childContextTypes: {
-    shortcuts: React.PropTypes.object.isRequired,
+    shortcuts: PropTypes.object.isRequired,
   },
 
   getInitialState() {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "events": "^1.0.2",
     "invariant": "^2.1.0",
     "lodash": "^4.15.0",
-    "platform": "^1.3.0"
+    "platform": "^1.3.0",
+    "prop-types": "^15.5.8"
   },
   "peerDependencies": {
     "react": "^0.14.8 || ^15",

--- a/src/component/shortcuts.js
+++ b/src/component/shortcuts.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import invariant from 'invariant'
 import Combokeys from 'combokeys'
+import PropTypes from 'prop-types'
 
 import helpers from '../helpers'
 
@@ -11,22 +12,22 @@ export default class extends React.Component {
   static displayName = 'Shortcuts'
 
   static contextTypes = {
-    shortcuts: React.PropTypes.object.isRequired,
+    shortcuts: PropTypes.object.isRequired,
   }
 
   static propTypes = {
-    children: React.PropTypes.node,
-    handler: React.PropTypes.func,
-    name: React.PropTypes.string,
-    tabIndex: React.PropTypes.number,
-    className: React.PropTypes.string,
-    eventType: React.PropTypes.string,
-    stopPropagation: React.PropTypes.bool,
-    preventDefault: React.PropTypes.bool,
-    targetNodeSelector: React.PropTypes.string,
-    global: React.PropTypes.bool,
-    isolate: React.PropTypes.bool,
-    alwaysFireHandler: React.PropTypes.bool,
+    children: PropTypes.node,
+    handler: PropTypes.func,
+    name: PropTypes.string,
+    tabIndex: PropTypes.number,
+    className: PropTypes.string,
+    eventType: PropTypes.string,
+    stopPropagation: PropTypes.bool,
+    preventDefault: PropTypes.bool,
+    targetNodeSelector: PropTypes.string,
+    global: PropTypes.bool,
+    isolate: PropTypes.bool,
+    alwaysFireHandler: PropTypes.bool,
   }
 
   static defaultProps = {


### PR DESCRIPTION
With React 15.5.0, [`React.PropTypes` are now extracted to a separate package](https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html#migrating-from-react.proptypes). 

They are still accessible via the main React object, but using them will log a deprecation warning to the console when in development mode.

![screen shot 2017-04-08 at 16 55 03](https://cloud.githubusercontent.com/assets/494699/24829942/3390e426-1c7c-11e7-8ee3-28720e13eb99.png)
