### PR TITLE
Bump react version support 

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
     "prop-types": "^15.5.8"
   },
   "peerDependencies": {
-    "react": "^0.14.8 || ^15",
-    "react-dom": "^0.14.8 || ^15"
+    "react": "^0.14.8 || ^15 || ^16",
+    "react-dom": "^0.14.8 || ^15 || ^16"
   },
   "repository": {
     "type": "git",
@@ -71,9 +71,9 @@
     "less-loader": "^2.2.0",
     "lodash": "^4.15.0",
     "mocha": "^2.2.5",
-    "react": "^0.14.8 || ^15",
-    "react-addons-test-utils": "^0.14.8 || ^15",
-    "react-dom": "^0.14.8 || ^15",
+    "react": "^0.14.8 || ^15 || ^16",
+    "react-addons-test-utils": "^0.14.8 || ^15 || ^16",
+    "react-dom": "^0.14.8 || ^15 || ^16",
     "simulant": "^0.2.2",
     "sinon": "^1.17.5",
     "sinon-chai": "^2.8.0",


### PR DESCRIPTION
This is a simple PR to bump the supported react version and that is following the same current used patterns. The main purpose is to get rid of the warnings when install that dependency with react@^16.

/CC @petrbrzek  